### PR TITLE
Fix compilation issues on the CTP7

### DIFF
--- a/include/RPC.hpp
+++ b/include/RPC.hpp
@@ -5,6 +5,7 @@
 #include <type_traits>
 #include <utility>
 #include <tuple>
+#include <typeinfo>
 
 // Supported types
 #include <cstdint>
@@ -323,8 +324,8 @@ namespace RPC {
             template<typename Tuple, std::size_t... I>
             Tuple get(index_sequence<I...>)
             {
-                // Initializer lists are always evaluated from left to right
-                return {
+                // Initializer-lists are always evaluated from left to right
+                return Tuple{
                     Serializer<typename std::decay<
                         typename std::tuple_element<I, Tuple>::type>
                     ::type>::to(*this)...
@@ -546,7 +547,7 @@ namespace RPC {
      */
     template<typename Method,
              typename... Args,
-             typename std::enable_if<std::is_base_of<RPC::Method, Method>::value, int>::type = 0
+             typename std::enable_if<std::is_base_of<RPC::Method, Method>::value, int>::type
             >
     functor_return_t<Method> Connection::call(Args&&... args)
     {


### PR DESCRIPTION
I think the commit message speaks by itself :

> Three compilation issues are addressed is this commit :
> 
> 1. The missing `typeinfo` header is included in order to access
>    the `typeid` operator.
> 
> 2. GCC 4.9.2 does not implement N4387 so we need to explicitely
>    construct the returned `std::tuple`.
> 
> 3. In `Connection::call`, the default template argument must not
>    be set in the definition of the method, only in the declaration.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
